### PR TITLE
fix: Handle hyphenated resource names with toYaml and empty dicts

### DIFF
--- a/yaml2helm/chartwriter.py
+++ b/yaml2helm/chartwriter.py
@@ -489,8 +489,12 @@ class ChartWriter:
                 # Add comment for resource sections
                 if indent == 0:
                     file.write(f"# Configuration for {key}\n")
-                file.write(f"{indent_str}{key}:\n")
-                self._write_values_with_comments(file, value, indent + 1)
+                # If empty dict, write {} instead of null
+                if not value:
+                    file.write(f"{indent_str}{key}: {{}}\n")
+                else:
+                    file.write(f"{indent_str}{key}:\n")
+                    self._write_values_with_comments(file, value, indent + 1)
             elif isinstance(value, list):
                 file.write(f"{indent_str}{key}:\n")
                 for item in value:

--- a/yaml2helm/extractors.py
+++ b/yaml2helm/extractors.py
@@ -151,7 +151,11 @@ class ValueExtractor:
                 if containers and isinstance(containers[0], dict) and 'resources' in containers[0]:
                     resource_values['resources'] = containers[0]['resources']
                     values_path = make_values_path(f"{resource_key}.resources")
-                    containers[0]['resources'] = f"{{{{- toYaml {values_path} | nindent 10 }}}}"
+                    # Wrap in parens if using index function
+                    if values_path.startswith('index'):
+                        containers[0]['resources'] = f"{{{{- toYaml ({values_path}) | nindent 10 }}}}"
+                    else:
+                        containers[0]['resources'] = f"{{{{- toYaml {values_path} | nindent 10 }}}}"
 
             # Extract nodeSelector
             node_selector_path = 'spec.template.spec.nodeSelector' if kind in ['Deployment', 'StatefulSet'] else 'spec.nodeSelector'
@@ -159,7 +163,11 @@ class ValueExtractor:
             if node_selector:
                 resource_values['nodeSelector'] = node_selector
                 values_path = make_values_path(f"{resource_key}.nodeSelector")
-                set_nested_value(resource, node_selector_path, f"{{{{- toYaml {values_path} | nindent 8 }}}}")
+                # Wrap in parens if using index function
+                if values_path.startswith('index'):
+                    set_nested_value(resource, node_selector_path, f"{{{{- toYaml ({values_path}) | nindent 8 }}}}")
+                else:
+                    set_nested_value(resource, node_selector_path, f"{{{{- toYaml {values_path} | nindent 8 }}}}")
 
         elif kind == 'Service':
             if 'spec' in resource:
@@ -171,7 +179,11 @@ class ValueExtractor:
                 if 'ports' in resource['spec']:
                     resource_values['ports'] = resource['spec']['ports']
                     values_path = make_values_path(f"{resource_key}.ports")
-                    resource['spec']['ports'] = f"{{{{- toYaml {values_path} | nindent 2 }}}}"
+                    # Wrap in parens if using index function
+                    if values_path.startswith('index'):
+                        resource['spec']['ports'] = f"{{{{- toYaml ({values_path}) | nindent 2 }}}}"
+                    else:
+                        resource['spec']['ports'] = f"{{{{- toYaml {values_path} | nindent 2 }}}}"
 
         # Extract environment variables
         self._extract_env_vars_scoped(resource, resource_key, resource_values)
@@ -302,7 +314,11 @@ class ValueExtractor:
 
         # For complex types, use toYaml
         if isinstance(value, (dict, list)):
-            template = f"{{{{- toYaml {values_path} | nindent 8 }}}}"
+            # Wrap in parens if using index function
+            if values_path.startswith('index'):
+                template = f"{{{{- toYaml ({values_path}) | nindent 8 }}}}"
+            else:
+                template = f"{{{{- toYaml {values_path} | nindent 8 }}}}"
 
         set_nested_value(resource, field_path, template)
 


### PR DESCRIPTION
## Problem
GitHub Actions integration tests were failing with two errors:

1. **Helm template error**: `wrong number of args for toYaml: want 1 got 4`
   - When resource names contain hyphens, we use `index` function
   - The template became: `{{- toYaml index .Values "name" "field" | nindent 2 }}`
   - Helm parsed this as toYaml with 4 args instead of 1

2. **Schema validation error**: `Invalid type. Expected: object, given: null`
   - ConfigMap and Secret resources had no extracted values
   - values.yaml wrote `app-config:` with nothing after = null
   - Schema expected object type

## Solution

1. **Wrap index calls in parentheses**:
   - Changed: `{{- toYaml index .Values "name" "field" | nindent 2 }}`
   - To: `{{- toYaml (index .Values "name" "field") | nindent 2 }}`
   - Now Helm correctly parses as toYaml with 1 argument

2. **Write empty dicts as {}**:
   - Changed: `app-config:` (becomes null)
   - To: `app-config: {}` (valid empty object)
   - Matches JSON schema expectations

## Testing

- ✅ All 19 unit tests passing
- ✅ Integration test with helm lint passing
- ✅ Integration test with helm template passing
- ✅ Manual testing with hyphenated resource names successful

## Files Changed

- `yaml2helm/extractors.py`: Added parentheses wrapping for index function calls
- `yaml2helm/chartwriter.py`: Write {} for empty dicts in values.yaml