### PR TITLE
Publish yaml2helm to PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,8 @@ temp/
 IMPROVEMENTS-IMPLEMENTED.md
 *-COMPARISON.md
 PROJECT-SUMMARY.md
+MONETIZATION-PLAN.md
+
+# Publishing helpers
+publish-to-pypi.sh
+Formula/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 C Turner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # yaml2helm
 
+[![Tests](https://github.com/thecturner/yaml2helm/actions/workflows/test.yml/badge.svg)](https://github.com/thecturner/yaml2helm/actions/workflows/test.yml)
+![Python Version](https://img.shields.io/badge/python-3.11%20%7C%203.12-blue)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
+
 Convert Kubernetes YAML manifests into Helm charts automatically.
 
 ## Features
@@ -20,12 +25,24 @@ Convert Kubernetes YAML manifests into Helm charts automatically.
 
 ## Installation
 
+### PyPI (recommended)
+
 ```bash
-pip install -e .
+pip install yaml2helm
 ```
 
-For development:
+### Homebrew (macOS)
+
 ```bash
+# Coming soon
+brew install yaml2helm
+```
+
+### From source
+
+```bash
+git clone https://github.com/thecturner/yaml2helm.git
+cd yaml2helm
 pip install -e ".[dev]"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,22 @@
 [project]
 name = "yaml2helm"
 version = "0.1.0"
-description = "Convert Kubernetes YAML manifests into Helm charts"
-authors = [{name = "Your Name"}]
+description = "Convert Kubernetes YAML manifests into Helm charts automatically"
+readme = "README.md"
+authors = [{name = "C Turner", email = "chris@example.com"}]
+license = "MIT"
 requires-python = ">=3.11"
+keywords = ["kubernetes", "helm", "yaml", "k8s", "converter", "devops"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: System :: Systems Administration",
+]
 dependencies = [
     "typer>=0.9.0",
     "ruamel.yaml>=0.18.0",
@@ -11,6 +24,11 @@ dependencies = [
     "jsonschema>=4.20.0",
     "rich>=13.0.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/thecturner/yaml2helm"
+Repository = "https://github.com/thecturner/yaml2helm"
+Issues = "https://github.com/thecturner/yaml2helm/issues"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

Published yaml2helm to PyPI and updated documentation.

- ✅ Published to PyPI: https://pypi.org/project/yaml2helm/
- ✅ Added MIT LICENSE file
- ✅ Enhanced pyproject.toml with complete PyPI metadata
- ✅ Updated README with pip install instructions and badges
- ✅ Verified installation from PyPI works correctly

## Changes

### New Files
- `LICENSE` - MIT license required for PyPI

### Modified Files
- `pyproject.toml` - Added author, keywords, classifiers, and project URLs
- `README.md` - Added badges and pip installation instructions
- `.gitignore` - Excluded publishing helper scripts

## Installation

Users can now install via:
```bash
pip install yaml2helm
```

## Testing

Verified installation in clean environment:
```bash
pip install yaml2helm
yaml2helm --help  # ✅ Works!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)